### PR TITLE
Drop taglib module

### DIFF
--- a/com.sayonara_player.Sayonara.json
+++ b/com.sayonara_player.Sayonara.json
@@ -44,20 +44,6 @@
             ]
         },
         {
-            "config-opts": [
-                "-DBUILD_SHARED_LIBS=ON"
-            ],
-            "name": "taglib",
-            "buildsystem": "cmake-ninja",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://taglib.org/releases/taglib-2.1.1.tar.gz",
-                    "sha256": "3716d31f7c83cbf17b67c8cf44dd82b2a2f17e6780472287a16823e70305ddba"
-                }
-            ]
-        },
-        {
             "name": "sayonara",
             "buildsystem": "cmake-ninja",
             "builddir": true,


### PR DESCRIPTION
Freedesktop runtime version 25.08 (also GNOME runtime 49, KDE runtime 6.10 and 5.15-25.08) provides taglib; therefore, it no longer needs to be compiled (unless the project requires a specific version of this dependency).

Fixes: https://github.com/flathub/com.sayonara_player.Sayonara/issues/14